### PR TITLE
handle async request.

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -53,6 +53,8 @@ aws_request(Method, Host, Path, Params, AccessKeyID, SecretAccessKey) ->
     aws_request(Method, undefined, Host, undefined, Path, Params, AccessKeyID, SecretAccessKey).
 aws_request(Method, Protocol, Host, Port, Path, Params, #aws_config{} = Config) ->
     case aws_request2(Method, Protocol, Host, Port, Path, Params, Config) of
+        ok ->
+            ok;
         {ok, Body} ->
             Body;
         {error, Reason} ->

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -10,10 +10,12 @@
          request_to_return/1,
          sign_v4/5]).
 
+export([do_async/1, do_async/2]).
+
 -include("erlcloud.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 
--record(metadata_credentials, 
+-record(metadata_credentials,
         {access_key_id :: string(),
          secret_access_key :: string(),
          security_token=undefined :: string(),
@@ -37,6 +39,8 @@ aws_request_xml2(Method, Host, Path, Params, #aws_config{} = Config) ->
     aws_request_xml2(Method, undefined, Host, undefined, Path, Params, Config).
 aws_request_xml2(Method, Protocol, Host, Port, Path, Params, #aws_config{} = Config) ->
     case aws_request2(Method, Protocol, Host, Port, Path, Params, Config) of
+        ok ->
+            ok;
         {ok, Body} ->
             {ok, element(1, xmerl_scan:string(binary_to_list(Body)))};
         {error, Reason} ->
@@ -79,14 +83,14 @@ aws_request2_no_update(Method, Protocol, Host, Port, Path, Params, #aws_config{}
                         undefined -> [];
                         Token -> [{"SecurityToken", Token}]
                     end),
-    
+
     QueryToSign = erlcloud_http:make_query_string(QParams),
     RequestToSign = [string:to_upper(atom_to_list(Method)), $\n,
                      string:to_lower(Host), $\n, Path, $\n, QueryToSign],
     Signature = base64:encode(erlcloud_util:sha_mac(Config#aws_config.secret_access_key, RequestToSign)),
-    
+
     Query = [QueryToSign, "&Signature=", erlcloud_http:url_encode(Signature)],
-    
+
     aws_request_form(Method, Protocol, Host, Port, Path, Query, [], Config).
 
 aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
@@ -94,12 +98,12 @@ aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
         undefined -> "https://";
         _ -> [Protocol, "://"]
     end,
-    
+
     URL = case Port of
         undefined -> [UProtocol, Host, Path];
         _ -> [UProtocol, Host, $:, port_to_str(Port), Path]
     end,
-    
+
     %% Note: httpc MUST be used with {timeout, timeout()} option
     %%       Many timeout related failures is observed at prod env
     %%       when library is used in 24/7 manner
@@ -111,11 +115,11 @@ aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
                   Req, get, Headers, <<>>, Config#aws_config.timeout, Config);
             _ ->
                 erlcloud_httpc:request(
-                  lists:flatten(URL), Method, 
+                  lists:flatten(URL), Method,
                   [{<<"content-type">>, <<"application/x-www-form-urlencoded; charset=utf-8">>} | Headers],
                   list_to_binary(Form), Config#aws_config.timeout, Config)
         end,
-    
+
     http_body(Response).
 
 param_list([], _Key) -> [];
@@ -193,8 +197,8 @@ get_metadata_credentials(Config) ->
 timestamp_to_gregorian_seconds(Timestamp) ->
     {ok, [Yr, Mo, Da, H, M, S], []} = io_lib:fread("~d-~d-~dT~d:~d:~dZ", binary_to_list(Timestamp)),
     calendar:datetime_to_gregorian_seconds({{Yr, Mo, Da}, {H, M, S}}).
-    
--spec get_credentials_from_metadata(aws_config()) 
+
+-spec get_credentials_from_metadata(aws_config())
                                    -> {ok, #metadata_credentials{}} | {error, term()}.
 get_credentials_from_metadata(Config) ->
     %% TODO this function should retry on errors getting credentials
@@ -210,7 +214,7 @@ get_credentials_from_metadata(Config) ->
             [Role | _] = binary:split(Body, <<$\n>>),
             case http_body(
                    erlcloud_httpc:request(
-                     "http://169.254.169.254/latest/meta-data/iam/security-credentials/" ++ 
+                     "http://169.254.169.254/latest/meta-data/iam/security-credentials/" ++
                          binary_to_list(Role),
                      get, [], <<>>, Config#aws_config.timeout, Config)) of
                 {error, Reason} ->
@@ -233,7 +237,7 @@ port_to_str(Port) when is_integer(Port) ->
 port_to_str(Port) when is_list(Port) ->
     Port.
 
--spec http_body({ok, tuple()} | {error, term()}) 
+-spec http_body({ok, tuple()} | {error, term()})
                -> {ok, string() | binary()} | {error, tuple()}.
 %% Extract the body and do error handling on the return of a httpc:request call.
 http_body(Return) ->
@@ -245,10 +249,12 @@ http_body(Return) ->
     end.
 
 -type headers() :: [{string(), string()}].
--spec http_headers_body({ok, tuple()} | {error, term()}) 
+-spec http_headers_body({ok, tuple()} | {error, term()})
                        -> {ok, {headers(), string() | binary()}} | {error, tuple()}.
 %% Extract the headers and body and do error handling on the return of a httpc:request call.
-http_headers_body({ok, {{OKStatus, _StatusLine}, Headers, Body}}) 
+http_headers_body(ok) ->
+    ok;
+http_headers_body({ok, {{OKStatus, _StatusLine}, Headers, Body}})
   when OKStatus >= 200, OKStatus =< 299 ->
     {ok, {Headers, Body}};
 http_headers_body({ok, {{Status, StatusLine}, _Headers, Body}}) ->
@@ -257,12 +263,12 @@ http_headers_body({error, Reason}) ->
     {error, {socket_error, Reason}}.
 
 %% Convert an aws_request record to return value as returned by http_headers_body
-request_to_return(#aws_request{response_type = ok, 
-                               response_headers = Headers, 
+request_to_return(#aws_request{response_type = ok,
+                               response_headers = Headers,
                                response_body = Body}) ->
     {ok, {Headers, Body}};
 request_to_return(#aws_request{response_type = error,
-                               error_type = httpc, 
+                               error_type = httpc,
                                httpc_error_reason = Reason}) ->
     {error, {socket_error, Reason}};
 request_to_return(#aws_request{response_type = error,
@@ -289,7 +295,7 @@ sign_v4(Config, Headers, Payload, Region, Service) ->
     Signature = base16(erlcloud_util:sha256_mac( SigningKey, ToSign)),
     Authorization = authorization(Config, CredentialScope, SignedHeaders, Signature),
     [{"Authorization", lists:flatten(Authorization)} | Headers2].
-    
+
 iso_8601_basic_time() ->
     {{Year,Month,Day},{Hour,Min,Sec}} = calendar:now_to_universal_time(os:timestamp()),
     lists:flatten(io_lib:format(
@@ -327,13 +333,13 @@ base16(Data) ->
 credential_scope(Date, Region, Service) ->
     DateOnly = string:left(Date, 8),
     [DateOnly, $/, Region, $/, Service, "/aws4_request"].
-    
+
 to_sign(Date, CredentialScope, Request) ->
     ["AWS4-HMAC-SHA256\n",
      Date, $\n,
      CredentialScope, $\n,
      hash_encode(Request)].
-    
+
 signing_key(Config, Date, Region, Service) ->
     %% TODO cache the signing key so we don't have to recompute for every request
     DateOnly = string:left(Date, 8),
@@ -341,9 +347,21 @@ signing_key(Config, Date, Region, Service) ->
     KRegion = erlcloud_util:sha256_mac( KDate, Region),
     KService = erlcloud_util:sha256_mac( KRegion, Service),
     erlcloud_util:sha256_mac( KService, "aws4_request").
-    
+
 authorization(Config, CredentialScope, SignedHeaders, Signature) ->
     ["AWS4-HMAC-SHA256"
      " Credential=", Config#aws_config.access_key_id, $/, CredentialScope, $,,
      " SignedHeaders=", SignedHeaders, $,,
      " Signature=", Signature].
+
+
+do_async(F) ->
+    do_async(F, nil).
+
+do_async(F, To) ->
+    erlang:put(aws_async_request, To),
+    try
+        F()
+    after
+        erlang:delete(aws_async_request)
+    end.

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -17,11 +17,29 @@ request(URL, Method, Hdrs, Body, Timeout, Config) ->
     Options = [{recv_timeout, Timeout},
                {connect_timeout, Timeout}],
 
-    case hackney_pooler:request(?POOL_NAME, Method, URL, Hdrs, Body, Options, available_worker, infinity) of
+    case is_async() of
+        false -> do_sync_request(URL, Method, Hdrs, Body, Options);
+        To -> do_async_request(To, URL, Method, Hdrs, Body, Options)
+    end.
+
+
+do_sync_request(URL, Method, Hdrs, Body, Options) ->
+    case hackney_pooler:request(?POOL_NAME, Method, URL, Hdrs, Body, Options,
+                                available_worker, infinity) of
         {ok, Status, RespHeaders, RespBody} ->
             {ok, {{Status, <<>>}, RespHeaders, RespBody}};
         {ok, Status, RespHeaders} ->
             {ok, {{Status, <<>>}, RespHeaders, <<>>}};
         Error ->
             Error
+    end.
+
+do_async_request(To, URL, Method, Hdrs, Body, Options) ->
+    hackney_pooler:async_request(?POOL_NAME, To, URL, Method, Hdrs, Body,
+                                 Options, available_worker).
+
+is_async() ->
+    case get(aws_async_request) of
+        undefined -> false;
+        To -> To
     end.

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -16,9 +16,9 @@
          receive_message/5, receive_message/6,
          remove_permission/2, remove_permission/3,
          send_message/2, send_message/3, send_message/4,
+         send_async_message/2, send_async_message/3, send_async_message/4,
          set_queue_attributes/2, set_queue_attributes/3
         ]).
-
 -include_lib("erlcloud/include/erlcloud.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 
@@ -353,6 +353,30 @@ send_message(QueueName, MessageBody, DelaySeconds, Config)
       ],
       Doc
      ).
+
+-spec send_async_message/2 :: (string(), string()) -> ok.
+send_async_message(QueueName, MessageBody) ->
+    send_async_message(QueueName, MessageBody, default_config()).
+
+-spec send_async_message/3 :: (string(), string(), 0..900 | none |
+                               aws_config()) -> ok.
+send_async_message(QueueName, MessageBody, Config)
+  when is_record(Config, aws_config) ->
+    send_async_message(QueueName, MessageBody, none, Config);
+send_async_message(QueueName, MessageBody, DelaySeconds) ->
+    send_async_message(QueueName, MessageBody, DelaySeconds, default_config()).
+
+-spec send_async_message/4 :: (string(), string(), 0..900, aws_config()) -> ok.
+send_async_message(QueueName, MessageBody, DelaySeconds, Config)
+  when is_list(QueueName), is_list(MessageBody),
+       (DelaySeconds >= 0 andalso DelaySeconds =< 900) orelse
+       DelaySeconds =:= none ->
+    erlcloud_aws:do_async(
+      fun() ->
+              sqs_xml_request(Config, QueueName,  "SendMessage",
+                              [{"MessageBody", MessageBody},
+                               {"DelaySeconds", DelaySeconds}])
+      end).
 
 -spec set_queue_attributes/2 :: (string(), [{visibility_timeout, integer()} | {policy, string()}]) -> ok.
 set_queue_attributes(QueueName, Attributes) ->

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -373,7 +373,7 @@ send_async_message(QueueName, MessageBody, DelaySeconds, Config)
        DelaySeconds =:= none ->
     erlcloud_aws:do_async(
       fun() ->
-              sqs_xml_request(Config, QueueName,  "SendMessage",
+              sqs_request(Config, QueueName,  "SendMessage",
                               [{"MessageBody", MessageBody},
                                {"DelaySeconds", DelaySeconds}])
       end).


### PR DESCRIPTION
this changes add support of asynchronous requests in erlcloud_httpc. For now only erlcloud:sqs:send_async_message/{2,3,4} supports it.
