### PR TITLE
allows multiple pools to use

### DIFF
--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -16,6 +16,6 @@
                   hackney_pooler]},
   {included_applications, [idna]},
   {modules, []},
-  {env, [{pools, [{erlcloud_pool, [{pool_size, 500}]}]}
+  {env, [{pools, [{erlcloud_pool, [{pool_size, 500}]}]}]}
  ]
 }.

--- a/src/erlcloud.app.src
+++ b/src/erlcloud.app.src
@@ -16,6 +16,6 @@
                   hackney_pooler]},
   {included_applications, [idna]},
   {modules, []},
-  {env, [{pool_size, 500}]}
+  {env, [{pools, [{erlcloud_pool, [{pool_size, 500}]}]}
  ]
 }.

--- a/src/erlcloud.erl
+++ b/src/erlcloud.erl
@@ -9,7 +9,7 @@ start() ->
     %% start pools
     application:ensure_all_started(hackney_pooler),
     lists:foreach(fun({PoolName, Config}) ->
-                          PoolSize = prolists:get_valuev(workers, Config, 50),
+                          PoolSize = proplists:get_value(workers, Config, 50),
                           MaxConn = proplists:get_value(maxconn, Config, 50),
                           Concurrency = proplists:get_value(concurrency, Config, 50),
                           PoolConfig = [{concurrency, Concurrency},

--- a/src/erlcloud.erl
+++ b/src/erlcloud.erl
@@ -2,20 +2,23 @@
 -export([start/0]).
 
 -define(APP, erlcloud).
--define(POOL_NAME, erlcloud_pool).
+
+-define(DEFAULT_POOLS, [{erlcloud_pool, []}]).
 
 start() ->
-    application:load(?APP),
-    {ok, Apps} = application:get_key(?APP, applications),
-    [application:start(App) || App <- Apps],
-    PoolSize = application:get_env(?APP, workers, 50),
-    MaxConn = application:get_env(?APP, maxconn, 50),
-    Concurrency = application:get_env(?APP, concurrency, 50),
-    {ok, _} = application:ensure_all_started(hackney_pooler),
-    PoolConfig = [{concurrency, Concurrency},
-                  {maxconn, MaxConn},
-                  {group, erlcloud},
-                  {max_count, PoolSize},
-                  {init_count, PoolSize}],
-    hackney_pooler:new_pool(?POOL_NAME, PoolConfig),
-    application:start(?APP).
+    %% start pools
+    application:ensure_all_started(hackney_pooler),
+    lists:foreach(fun({PoolName, Config}) ->
+                          PoolSize = prolists:get_valuev(workers, Config, 50),
+                          MaxConn = proplists:get_value(maxconn, Config, 50),
+                          Concurrency = proplists:get_value(concurrency, Config, 50),
+                          PoolConfig = [{concurrency, Concurrency},
+                                        {maxconn, MaxConn},
+                                        {group, erlcloud},
+                                        {max_count, PoolSize},
+                                        {init_count, PoolSize}],
+                          hackney_pooler:new_pool(PoolName, PoolConfig)
+                  end, application:get_env(?APP, pools, ?DEFAULT_POOLS)),
+    %% start the application
+    {ok, _} = application:ensure_all_started(?APP),
+    ok.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -11,6 +11,7 @@
          sign_v4/5]).
 
 -export([do_async/1, do_async/2]).
+-export([set_pool/0, set_pool/1]).
 
 -include("erlcloud.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
@@ -21,6 +22,8 @@
          security_token=undefined :: string(),
          expiration_gregorian_seconds :: integer()
         }).
+
+-define(DEFAULT_POOL, erlcloud_pool).
 
 aws_request_xml(Method, Host, Path, Params, #aws_config{} = Config) ->
     Body = aws_request(Method, Host, Path, Params, Config),
@@ -368,3 +371,9 @@ do_async(F, To) ->
     after
         erlang:erase(aws_async_request)
     end.
+
+set_pool() ->
+    set_pool(?DEFAULT_POOL).
+
+set_pool(PoolName) ->
+    erlang:put(aws_pool, PoolName).

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -35,11 +35,17 @@ do_sync_request(URL, Method, Hdrs, Body, Options) ->
     end.
 
 do_async_request(To, URL, Method, Hdrs, Body, Options) ->
-    hackney_pooler:async_request(?POOL_NAME, To, Method, URL, Hdrs, Body,
+    hackney_pooler:async_request(pool(), To, Method, URL, Hdrs, Body,
                                  Options, available_worker).
 
 is_async() ->
     case get(aws_async_request) of
         undefined -> false;
         To -> To
+    end.
+
+pool() ->
+    case get(aws_pool) of
+        undefined -> ?POOL_NAME;
+        PoolName -> PoolName
     end.


### PR DESCRIPTION
add `erlcloud_aws:set_pool/{0,1}` to set a pool in the process doing the AWS
request.
