### PR TITLE
Fix async calls handling in retry implementation

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -279,6 +279,10 @@ http_headers_body({error, Reason}) ->
 
 %% Convert an aws_request record to return value as returned by http_headers_body
 request_to_return(#aws_request{response_type = ok,
+                               response_headers = undefined,
+                               response_body = undefined}) ->
+    ok;
+request_to_return(#aws_request{response_type = ok,
                                response_headers = Headers,
                                response_body = Body}) ->
     {ok, {Headers, Body}};

--- a/src/erlcloud_retry.erl
+++ b/src/erlcloud_retry.erl
@@ -80,6 +80,8 @@ request_and_retry(Config, ResultFun, {retry, Request}) ->
                 error ->
                     request_and_retry(Config, ResultFun, RetryFun(Request4))
             end;
+        ok ->
+            Request2#aws_request{ response_type = ok, error_type = aws };
         {error, Reason} ->
             Request4 = Request2#aws_request{
                          response_type = error,


### PR DESCRIPTION
Fixes the case clause errors we were getting on async calls. This is only a quick fix, the ultimate goal is to have proper retry mechanism for async calls too.
