### PR TITLE
[erlcloud_retry_sup] Change worker type to temporary

### DIFF
--- a/src/erlcloud_retry_sup.erl
+++ b/src/erlcloud_retry_sup.erl
@@ -34,7 +34,7 @@ start_retry_handler(Config, Request) ->
                                     [supervisor:child_spec()]}}
                               | ignore.
 init([]) ->
-    ChildSpec = {undefined, {erlcloud_retry, start_link, []}, transient,
+    ChildSpec = {undefined, {erlcloud_retry, start_link, []}, temporary,
                  5000, worker, [erlcloud_retry]},
     {ok, {{simple_one_for_one, 5, 10}, [ChildSpec]}}.
 


### PR DESCRIPTION
With `transient` type we'll end up with lots of dead workers in supervisor state. :)
